### PR TITLE
fix: add client response type inference when options.throw is true

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -214,4 +214,58 @@ describe("client", () => {
 		});
 		expectTypeOf<Parameters<typeof client>[0]>().toMatchTypeOf<"@post/test">();
 	});
+
+	it("should infer response depending on options.throw", async () => {
+		const endpoint = createEndpoint(
+			"/test",
+			{
+				method: "POST",
+				body: z.object({
+					hello: z.string(),
+				}),
+			},
+			async () => {
+				return {
+					status: 200,
+					body: {
+						hello: "world",
+					},
+				};
+			},
+		);
+
+		const router = createRouter({
+			endpoint,
+		});
+
+		const client = createClient<typeof router>({
+			baseURL: "http://localhost:3000",
+			customFetchImpl: async () => {
+				return new Response(null);
+			},
+		});
+
+		const throwingClient = createClient<typeof router>({
+			baseURL: "http://localhost:3000",
+			customFetchImpl: async () => {
+				return new Response(null);
+			},
+			throw: true,
+		});
+
+		const response = await client("@post/test", {
+			body: {
+				hello: "world",
+			},
+		});
+
+		const throwingResponse = await throwingClient("@post/test", {
+			body: {
+				hello: "world",
+			},
+		});
+
+		expectTypeOf(response.data).toMatchTypeOf<{ body: { hello: string } } | null>();
+		expectTypeOf(throwingResponse).toMatchTypeOf<{ body: { hello: string } }>();
+	});
 });


### PR DESCRIPTION
Hello ! 
I had an issue with the return type of the better-fetch client when using { throw: true } : 
```ts
const api = createClient<AppRouter>({
  throw: true,
});


const api2 = createClient<AppRouter>({
  throw: false,
});

const resp1 = await api("/is-first-connection", {});
const resp2 = await api2("/is-first-connection", {});

type AreResponsesEqual = typeof resp1 extends typeof resp2 ? true : false;
//   ^? type AreResponsesEqual = true
```

So I've used function overloading to fix it.

If you think of a better way of achieving this, please let me know :)