### PR TITLE
fix: return setResponse promise so that it can be caught on fatal error

### DIFF
--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -9,7 +9,7 @@ export function toNodeHandler(handler: Router["handler"]) {
 			req.headers["x-forwarded-proto"] || ((req.socket as any).encrypted ? "https" : "http");
 		const base = `${protocol}://${req.headers[":authority"] || req.headers.host}`;
 		const response = await handler(getRequest({ base, request: req }));
-		setResponse(res, response);
+		return setResponse(res, response);
 	};
 }
 

--- a/src/adapters/node/node.ts
+++ b/src/adapters/node/node.ts
@@ -9,7 +9,7 @@ export function toNodeHandler(handler: Router["handler"]) {
 			req.headers["x-forwarded-proto"] || ((req.socket as any).encrypted ? "https" : "http");
 		const base = `${protocol}://${req.headers[":authority"] || req.headers.host}`;
 		const response = await handler(getRequest({ base, request: req }));
-		setResponse(res, response);
+		return setResponse(res, response);
 	};
 }
 


### PR DESCRIPTION
Context: I'm using better-auth (it's been really nice so far!) with [Effect](https://effect.website/) using the `toNodeHandler`; I sometimes (i'm not sure how to 100% reproduce it ?) get this error:
 
```sh
node:_http_outgoing:848
    throw new ERR_HTTP_HEADERS_SENT('remove');
          ^

Error [ERR_HTTP_HEADERS_SENT]: Cannot remove headers after they are sent to the client
    at ServerResponse.removeHeader (node:_http_outgoing:848:11)
    at file:///backend/node_modules/.pnpm/better-call@0.3.3/node_modules/better-call/dist/index.js:988:50
    at Array.forEach (<anonymous>)
    at setResponse (file:///backend/node_modules/.pnpm/better-call@0.3.3/node_modules/better-call/dist/index.js:988:28)
    at file:///backend/node_modules/.pnpm/better-call@0.3.3/node_modules/better-call/dist/index.js:1042:5
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async file:///backend/packages/backend/src/http/better-auth.api.live.ts:36:4 {
  code: 'ERR_HTTP_HEADERS_SENT'
}
```

returning the promise allows me to catch it when it fails early; otherwise I can't do anything and the error becomes a fatal error

one thing I'm not sure of is whether or not this `next` method (returning a promise) should also be returned or not:
https://github.com/astahmer/better-call/blob/6e226e8aac190f8a0325e4576d55c19a82500006/src/adapters/node/request.ts#L158