### PR TITLE
fix: use cookie-es to parse cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,20 +20,21 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.16.4",
-    "arktype": "^2.0.0",
-    "zod": "^3.24.1",
-    "valibot": "1.0.0-beta.15",
     "@biomejs/biome": "^1.8.3",
     "@types/bun": "latest",
     "@types/set-cookie-parser": "^2.4.10",
+    "arktype": "^2.0.0",
     "bumpp": "^9.4.1",
     "tsup": "^8.3.5",
     "type-fest": "^4.23.0",
     "typescript": "^5.6.0-beta",
-    "vitest": "^3.0.3"
+    "valibot": "1.0.0-beta.15",
+    "vitest": "^3.0.3",
+    "zod": "^3.24.1"
   },
   "dependencies": {
     "@better-fetch/fetch": "^1.1.4",
+    "cookie-es": "^2.0.0",
     "rou3": "^0.5.1",
     "set-cookie-parser": "^2.7.1",
     "uncrypto": "^0.1.3"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@better-fetch/fetch": "^1.1.4",
-    "cookie-es": "^2.0.0",
     "rou3": "^0.5.1",
     "set-cookie-parser": "^2.7.1",
     "uncrypto": "^0.1.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@better-fetch/fetch':
         specifier: ^1.1.4
         version: 1.1.12
+      cookie-es:
+        specifier: ^2.0.0
+        version: 2.0.0
       rou3:
         specifier: ^0.5.1
         version: 0.5.1
@@ -735,6 +738,9 @@ packages:
   consola@3.4.0:
     resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  cookie-es@2.0.0:
+    resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1893,6 +1899,8 @@ snapshots:
   confbox@0.1.8: {}
 
   consola@3.4.0: {}
+
+  cookie-es@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@better-fetch/fetch':
         specifier: ^1.1.4
         version: 1.1.12
-      cookie-es:
-        specifier: ^2.0.0
-        version: 2.0.0
       rou3:
         specifier: ^0.5.1
         version: 0.5.1
@@ -738,9 +735,6 @@ packages:
   consola@3.4.0:
     resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  cookie-es@2.0.0:
-    resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1899,8 +1893,6 @@ snapshots:
   confbox@0.1.8: {}
 
   consola@3.4.0: {}
-
-  cookie-es@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from "vitest";
 import { createEndpoint } from "./endpoint";
 import { z } from "zod";
 import { signCookieValue } from "./crypto";
+import { parseCookies } from "./cookies";
+
+describe("parseCookies", () => {
+	it("should parse cookies", () => {
+		const cookies = parseCookies("test=test; test2=test2");
+		expect(cookies.get("test")).toBe("test");
+		expect(cookies.get("test2")).toBe("test2");
+	});
+
+	it("should parse cookies with encoded values", () => {
+		const cookies = parseCookies("test=test; test2=test%202");
+		expect(cookies.get("test")).toBe("test");
+		expect(cookies.get("test2")).toBe("test 2");
+	});
+});
 
 describe("get-cookies", () => {
 	it("should get cookies", async () => {

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -6,9 +6,9 @@ import { parseCookies } from "./cookies";
 
 describe("parseCookies", () => {
 	it("should parse cookies", () => {
-		const cookies = parseCookies("test=test; test2=test2");
+		const cookies = parseCookies("test=test; test2=test 2");
 		expect(cookies.get("test")).toBe("test");
-		expect(cookies.get("test2")).toBe("test2");
+		expect(cookies.get("test2")).toBe("test 2");
 	});
 
 	it("should parse cookies with encoded values", () => {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,3 +1,4 @@
+import { parse } from "cookie-es";
 import { signCookieValue } from "./crypto";
 
 export type CookiePrefixOptions = "host" | "secure";
@@ -104,14 +105,7 @@ export const getCookieKey = (key: string, prefix?: CookiePrefixOptions) => {
 };
 
 export function parseCookies(cookieHeader: string) {
-	const cookies = cookieHeader.split(";");
-	const cookieMap = new Map<string, string>();
-
-	cookies.forEach((cookie) => {
-		const [name, value] = cookie.trim().split("=");
-		cookieMap.set(name, decodeURIComponent(value));
-	});
-	return cookieMap;
+	return new Map<string, string>(Object.entries(parse(cookieHeader)));
 }
 
 const _serialize = (key: string, value: string, opt: CookieOptions = {}) => {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -117,7 +117,7 @@ export function parseCookies(str: string) {
 		throw new TypeError("argument str must be a string");
 	}
 
-	const obj: Map<string, string> = new Map();
+	const cookies: Map<string, string> = new Map();
 
 	let index = 0;
 	while (index < str.length) {
@@ -137,18 +137,18 @@ export function parseCookies(str: string) {
 		}
 
 		const key = str.slice(index, eqIdx).trim();
-		if (!obj.has(key)) {
+		if (!cookies.has(key)) {
 			let val = str.slice(eqIdx + 1, endIdx).trim();
 			if (val.codePointAt(0) === 0x22) {
 				val = val.slice(1, -1);
 			}
-			obj.set(key, tryDecode(val));
+			cookies.set(key, tryDecode(val));
 		}
 
 		index = endIdx + 1;
 	}
 
-	return obj;
+	return cookies;
 }
 
 const _serialize = (key: string, value: string, opt: CookieOptions = {}) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,3 +56,11 @@ export async function getBody(request: Request) {
 export function isAPIError(error: any) {
 	return error instanceof APIError || error?.name === "APIError";
 }
+
+export function tryDecode(str: string) {
+	try {
+		return str.includes("%") ? decodeURIComponent(str) : str;
+	} catch {
+		return str;
+	}
+}


### PR DESCRIPTION
This PR uses [cookie-es](https://github.com/unjs/cookie-es) to parse cookies, because it is more reliable than using `=` directly to split, and can support parsing unencoded cookies.

Currently, if the user passes an unencoded cookie, it will fail the validation of [`getSignedCookie`](https://github.com/Bekacru/better-call/blob/2b0303878682324d06943f31268d62f73077ebf9/src/context.ts#L205-L226) because the last character is `=`.
