### PR TITLE
feat: createEndpoint.modify

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -370,6 +370,24 @@ createEndpoint.create = <E extends { use?: Middleware[] }>(opts?: E) => {
 	};
 };
 
+createEndpoint.modify = (
+	original: Endpoint,
+	modifications?: {
+		path?: Endpoint["path"];
+		options?: Endpoint["options"];
+		handler?: (context: EndpointContext<Endpoint["path"], Endpoint["options"]>) => Promise<any>;
+	}
+) => {
+	return createEndpoint(
+		modifications?.path ?? original.path,
+		{
+			...original.options,
+			...(modifications?.options || {})
+		},
+		modifications?.handler ?? original
+	);
+};
+
 export type Endpoint<
 	Path extends string = string,
 	Options extends EndpointOptions = EndpointOptions,


### PR DESCRIPTION
Introduce a way to modify an endpoint after it's created.  This could be especially useful in consuming libraries (better-auth) when custom modifications are needed.

The would provide an escape hatch out of standard or rigid endpoints when needed