### PR TITLE
fix: added the case where the "x-forwarded-proto" header is a coma se…

### DIFF
--- a/src/adapters/node/node.ts
+++ b/src/adapters/node/node.ts
@@ -5,17 +5,18 @@ import type { Router } from "../../router.js";
 
 export function toNodeHandler(handler: Router["handler"]) {
   return async (req: IncomingMessage, res: ServerResponse) => {
-    // src/adapters/node/index.ts
     const forwarded = req.headers["x-forwarded-proto"];
-    // FIXME: THERE IS A CASE WHERE FORWARDED IS AN ARRAY,
-    // IF IT'S AN ARRAY I CHECK FOR HTTPS
-    // IF NOT I DEFAULT TO HTTP
+    // THERE IS A CASE WHERE FORWARDED IS AN ARRAY, OR A COMMA SEPARATED LIST
+    // IF IT'S AN ARRAY I CHECK FOR HTTPS IN IT
     const protocol = forwarded
       ? Array.isArray(forwarded)
         ? forwarded.includes("https")
           ? "https"
           : "http"
-        : forwarded.split(",")[0].trim() // The header can also be a string with coma so I just split it manually
+        : (()=>{
+          const parts = forwarded.split(",")
+          return parts.includes("https") ? "https" : parts[0].trim() // The header can also be a string with coma so I just split it manually
+        })() 
       : (req.socket as any).encrypted
         ? "https"
         : "http";

--- a/src/adapters/node/node.ts
+++ b/src/adapters/node/node.ts
@@ -4,13 +4,28 @@ import { getRequest, setResponse } from "./request";
 import type { Router } from "../../router.js";
 
 export function toNodeHandler(handler: Router["handler"]) {
-	return async (req: IncomingMessage, res: ServerResponse) => {
-		const protocol =
-			req.headers["x-forwarded-proto"] || ((req.socket as any).encrypted ? "https" : "http");
-		const base = `${protocol}://${req.headers[":authority"] || req.headers.host}`;
-		const response = await handler(getRequest({ base, request: req }));
-		return setResponse(res, response);
-	};
+  return async (req: IncomingMessage, res: ServerResponse) => {
+    // src/adapters/node/index.ts
+    const forwarded = req.headers["x-forwarded-proto"];
+    // FIXME: THERE IS A CASE WHERE FORWARDED IS AN ARRAY,
+    // IF IT'S AN ARRAY I CHECK FOR HTTPS
+    // IF NOT I DEFAULT TO HTTP
+    const protocol = forwarded
+      ? Array.isArray(forwarded)
+        ? forwarded.includes("https")
+          ? "https"
+          : "http"
+        : forwarded.split(",")[0].trim() // The header can also be a string with coma so I just split it manually
+      : (req.socket as any).encrypted
+        ? "https"
+        : "http";
+
+    const base = `${protocol}://${
+      req.headers[":authority"] || req.headers.host
+    }`;
+    const response = await handler(getRequest({ base, request: req }));
+    return setResponse(res, response);
+  };
 }
 
 export { getRequest, setResponse };


### PR DESCRIPTION
On some server/proxy, the "x-forwarded-proto" header has a value of "https, https" which throws an error when parsing a URL; for this case, I split the header manually before inferring the protocol