### PR TITLE
update: Allow customizing validation error

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import type { EndpointOptions } from "./endpoint";
-import { _statusCode, APIError, type Status } from "./error";
+import { _statusCode, APIError, ValidationError, type Status } from "./error";
 import type {
 	InferParamPath,
 	InferParamWildCard,
@@ -183,10 +183,7 @@ export const createInternalContext = async (
 	const headers = new Headers();
 	const { data, error } = await runValidation(options, context);
 	if (error) {
-		throw new APIError(400, {
-			message: error.message,
-			code: "VALIDATION_ERROR",
-		});
+		throw new ValidationError(error.message, error.issues);
 	}
 	const requestHeaders: Headers | null =
 		"headers" in context

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,3 +1,5 @@
+import type { StandardSchemaV1 } from "./standard-schema";
+
 export const _statusCode = {
 	OK: 200,
 	CREATED: 201,
@@ -143,5 +145,19 @@ export class APIError extends Error {
 				}
 			: undefined;
 		this.stack = "";
+	}
+}
+
+export class ValidationError extends APIError {
+	constructor(
+		public message: string,
+		public issues: readonly StandardSchemaV1.Issue[],
+	) {
+		super(400, {
+			message: message,
+			code: "VALIDATION_ERROR",
+		});
+
+		this.issues = issues;
 	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,3 +64,24 @@ export function tryDecode(str: string) {
 		return str;
 	}
 }
+
+type Success<T> = {
+	data: T;
+	error: null;
+};
+
+type Failure<E> = {
+	data: null;
+	error: E;
+};
+
+export type Result<T, E = Error> = Success<T> | Failure<E>;
+
+export async function tryCatch<T, E = Error>(promise: Promise<T>): Promise<Result<T, E>> {
+	try {
+		const data = await promise;
+		return { data, error: null };
+	} catch (error) {
+		return { data: null, error: error as E };
+	}
+}

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -14,6 +14,7 @@ type ValidationResponse =
 			data: null;
 			error: {
 				message: string;
+				issues: readonly StandardSchemaV1.Issue[];
 			};
 	  };
 
@@ -56,13 +57,13 @@ export async function runValidation(
 	if (options.requireHeaders && !context.headers) {
 		return {
 			data: null,
-			error: { message: "Headers is required" },
+			error: { message: "Headers is required", issues: [] },
 		};
 	}
 	if (options.requireRequest && !context.request) {
 		return {
 			data: null,
-			error: { message: "Request is required" },
+			error: { message: "Request is required", issues: [] },
 		};
 	}
 	return {
@@ -72,13 +73,8 @@ export async function runValidation(
 }
 
 export function fromError(error: readonly StandardSchemaV1.Issue[], validating: string) {
-	const errorMessages: string[] = [];
-
-	for (const issue of error) {
-		const message = issue.message;
-		errorMessages.push(message);
-	}
 	return {
 		message: `Invalid ${validating} parameters`,
+		issues: error,
 	};
 }


### PR DESCRIPTION
This PR adds a `onValidationError` in the endpoint options to allow devs to intercept the validation error and throw their own custom error message if desired.