### PR TITLE
fix(node): handle node mount path in Request URL

### DIFF
--- a/src/adapters/node/request.ts
+++ b/src/adapters/node/request.ts
@@ -95,7 +95,12 @@ export function getRequest({
 	bodySizeLimit?: number;
 	request: IncomingMessage;
 }) {
-	return new Request(base + request.url, {
+	// In Express subrouters, `request.url` is relative to the mount path (e.g., '/auth/xxx'),
+	// and `request.baseUrl` holds the mount path (e.g., '/api').
+	// Build the full path as baseUrl + url when available to preserve the full route.
+	const baseUrl = (request as any)?.baseUrl as string | undefined;
+	const fullPath = baseUrl ? baseUrl + request.url : request.url;
+	return new Request(base + fullPath, {
 		// @ts-expect-error
 		duplex: "half",
 		method: request.method,

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -3,6 +3,7 @@ import { createEndpoint, type Endpoint } from "./endpoint";
 import { createRouter } from "./router";
 import { z } from "zod";
 import { APIError } from "./error";
+import { getRequest } from "./adapters/node/request";
 
 describe("router", () => {
 	it("should be able to return simple response", async () => {
@@ -201,6 +202,33 @@ describe("router", () => {
 		expect(response.status).toBe(200);
 		const text = await response.text();
 		expect(text).toBe("/test/api/v1/test");
+	});
+
+	it("node adapter getRequest should include Express baseUrl when present", async () => {
+		const base = "http://localhost:3000";
+		const fakeReq: any = {
+			headers: { host: "localhost:3000" },
+			method: "GET",
+			url: "/auth/callback",
+			baseUrl: "/api",
+			httpVersionMajor: 1,
+			destroyed: false,
+		};
+		const req = getRequest({ base, request: fakeReq });
+		expect(new URL(req.url).href).toBe("http://localhost:3000/api/auth/callback");
+	});
+
+	it("node adapter getRequest should fall back to url when baseUrl is missing", async () => {
+		const base = "http://localhost:3000";
+		const fakeReq: any = {
+			headers: { host: "localhost:3000" },
+			method: "GET",
+			url: "/auth/callback",
+			httpVersionMajor: 1,
+			destroyed: false,
+		};
+		const req = getRequest({ base, request: fakeReq });
+		expect(new URL(req.url).href).toBe("http://localhost:3000/auth/callback");
 	});
 });
 


### PR DESCRIPTION
This PR Fixes 404s when toNodeHandler is used inside an Express subrouter (e.g., mounted under /api). The Node adapter now constructs the full URL using req.baseUrl + req.url when baseUrl is present, preserving the mount path.

Related issue: better-auth/better-auth#3887

When mounted under a subrouter (e.g., /api), Express sets req.url to the route-relative path (e.g., /auth/...) and req.baseUrl to the mount path (e.g., /api). Previously, the adapter built the URL with base + req.url, which dropped the mount path.

before the patch
<img width="941" height="544" alt="Screenshot 2025-08-09 at 5 21 24 PM" src="https://github.com/user-attachments/assets/fd31fc33-67c3-43b3-b8df-bf87d9dbceaf" />
after the patch 

<img width="940" height="566" alt="Screenshot 2025-08-09 at 5 22 38 PM" src="https://github.com/user-attachments/assets/5d5bf27a-c04e-413e-a6ff-8f945bc33e7b" />
