### PR TITLE
feat/return-cookies

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -166,6 +166,7 @@ export type InputContext<
 	InferHeadersInput<Options> & {
 		asResponse?: boolean;
 		returnHeaders?: boolean;
+		returnCookies?: boolean;
 		use?: Middleware[];
 		path?: string;
 	};

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -243,18 +243,18 @@ export const serializeSignedCookie = async (
 	return _serialize(key, value, opt);
 };
 
-export type ParsedSetCookie = {
+export type SetCookie = {
 	name: string;
 	value: string;
 } & CookieOptions;
 
-export function parseSetCookie(header: string): ParsedSetCookie {
+export function parseSetCookie(header: string): SetCookie {
 	const parts = header.split(";").map((p) => p.trim());
 	const [nameValue, ...attributes] = parts;
 	const [name, rawValue] = nameValue.split("=");
 	const value = decodeURIComponent(rawValue);
 
-	const cookie: ParsedSetCookie = { name, value };
+	const cookie: SetCookie = { name, value };
 
 	for (const attr of attributes) {
 		if (attr.includes("=")) {
@@ -289,4 +289,10 @@ export function parseSetCookie(header: string): ParsedSetCookie {
 	}
 
 	return cookie;
+}
+
+export type SetCookies = SetCookie[];
+
+export function extractSetCookes(headers: Headers): SetCookies {
+	return headers.getSetCookie().map((c) => parseSetCookie(c));
 }

--- a/src/endpoint.test.ts
+++ b/src/endpoint.test.ts
@@ -499,6 +499,28 @@ describe("response", () => {
 		});
 	});
 
+	describe("set-cookies", () => {
+		it("should set cookies", async () => {
+			const endpoint = createEndpoint(
+				"/endpoint",
+				{
+					method: "POST",
+				},
+				async (c) => {
+					c.setCookie("hello", "world");
+				},
+			);
+
+			const response = await endpoint({
+				returnCookies:true
+			});
+
+			expect(response.cookies).toHaveLength(1);
+			expect(response.cookies?.at(0)?.name).toBe("hello");
+			expect(response.cookies?.at(0)?.value).toBe("world");
+		});
+	});
+
 	describe("API Error", () => {
 		it("should throw API Error", async () => {
 			const endpoint = createEndpoint(

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -13,7 +13,12 @@ import {
 	type InputContext,
 	type Method,
 } from "./context";
-import { parseCookies, type CookieOptions, type CookiePrefixOptions } from "./cookies";
+import {
+	extractSetCookes,
+	type SetCookies,
+	type CookieOptions,
+	type CookiePrefixOptions,
+} from "./cookies";
 import { APIError, type _statusCode, type Status } from "./error";
 import type { OpenAPIParameter, OpenAPISchemaType } from "./openapi";
 import type { StandardSchemaV1 } from "./standard-schema";
@@ -320,13 +325,27 @@ export const createEndpoint = <Path extends string, Options extends EndpointOpti
 	handler: (context: EndpointContext<Path, Options>) => Promise<R>,
 ) => {
 	type Context = InputContext<Path, Options>;
+
 	const internalHandler = async <
 		AsResponse extends boolean = false,
 		ReturnHeaders extends boolean = false,
+		ReturnCookies extends boolean = false,
 	>(
 		...inputCtx: HasRequiredKeys<Context> extends true
-			? [Context & { asResponse?: AsResponse; returnHeaders?: ReturnHeaders }]
-			: [(Context & { asResponse?: AsResponse; returnHeaders?: ReturnHeaders })?]
+			? [
+					Context & {
+						asResponse?: AsResponse;
+						returnHeaders?: ReturnHeaders;
+						returnCookies?: ReturnCookies;
+					},
+				]
+			: [
+					(Context & {
+						asResponse?: AsResponse;
+						returnHeaders?: ReturnHeaders;
+						returnCookies?: ReturnCookies;
+					})?,
+				]
 	) => {
 		const context = (inputCtx[0] || {}) as InputContext<any, any>;
 		const internalContext = await createInternalContext(context, {
@@ -346,39 +365,41 @@ export const createEndpoint = <Path extends string, Options extends EndpointOpti
 			throw e;
 		});
 		const headers = internalContext.responseHeaders;
+
 		type ResultType = [AsResponse] extends [true]
 			? Response
-			: [ReturnHeaders] extends [true]
-				? { headers: Headers; response: R }
-				: R;
+			: [ReturnHeaders, ReturnCookies] extends [true, true]
+				? { response: R; headers: Headers; cookies: SetCookies | null }
+				: [ReturnHeaders, ReturnCookies] extends [true, false]
+					? { response: R; headers: Headers }
+					: [ReturnHeaders, ReturnCookies] extends [false, true]
+						? { response: R; cookies: SetCookies | null }
+						: R;
 
 		if (context.asResponse) {
-			return toResponse(response, {
-				headers,
-			});
-		} else {
-			if (context.returnHeaders && context.returnCookies) {
-				const setCookie = headers.get("set-cookie");
-				return {
-					response,
-					headers,
-					cookies: setCookie ? parseCookies(setCookie) : null,
-				} as ResultType;
-			}
-			if (context.returnHeaders) {
-				return { response, headers } as ResultType;
-			}
-
-			if (context.returnCookies) {
-				const setCookie = headers.get("set-cookie");
-				return {
-					response,
-					cookies: setCookie ? parseCookies(setCookie) : null,
-				} as ResultType;
-			}
-
-			return response as ResultType;
+			return toResponse(response, { headers }) as ResultType;
 		}
+
+		if (context.returnHeaders && context.returnCookies) {
+			return {
+				response,
+				headers,
+				cookies: extractSetCookes(headers),
+			} as ResultType;
+		}
+
+		if (context.returnHeaders) {
+			return { response, headers } as ResultType;
+		}
+
+		if (context.returnCookies) {
+			return {
+				response,
+				cookies: extractSetCookes(headers),
+			} as ResultType;
+		}
+
+		return response as ResultType;
 	};
 	internalHandler.options = options;
 	internalHandler.path = path;


### PR DESCRIPTION
This PR introduces support for the `returnCookies` field, which behaves similarly to the `returnHeaders` field. When enabled, the `returnCookies` field will parse all the cookies set by an endpoint and return them.

This feature is particularly useful for individuals using better auth as a server-only library. It allows them to avoid manually parsing the set cookie headers when they want to set them themselves via their preferred web framework.

https://github.com/better-auth/better-auth/issues/3851