### PR TITLE
feat: add `error` schema type on `EndpointOptions`

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -33,6 +33,10 @@ export interface EndpointOptions {
 	 */
 	query?: StandardSchemaV1;
 	/**
+	 * Error Schema
+	 */
+	error?: StandardSchemaV1;
+	/**
 	 * If true headers will be required to be passed in the context
 	 */
 	requireHeaders?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,7 +53,7 @@ export async function getBody(request: Request) {
 	return await request.text();
 }
 
-export function isAPIError(error: any) {
+export function isAPIError(error: any): error is APIError {
 	return error instanceof APIError || error?.name === "APIError";
 }
 


### PR DESCRIPTION
For PR: https://github.com/better-auth/better-auth/pull/3811

We need to customize the ApiError return type, since [rfc8628](https://datatracker.ietf.org/doc/html/rfc8628) has many custom error properties.

Related code: https://github.com/better-auth/better-auth/blob/2ebe80f42c89cd6a7a410b5a2bcbb19f8a12b7dd/packages/better-auth/src/client/path-to-object.ts#L133-L137