### PR TITLE
fix: set build target to es2022

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
 	splitting: false,
 	sourcemap: true,
 	format: ["esm", "cjs"],
-	target: "es2020",
+	target: "es2022",
 	bundle: true,
 });


### PR DESCRIPTION
Fixes: https://github.com/Bekacru/better-call/issues/38

prev:

```js
function makeErrorForHideStackFrame(Base, clazz) {
  var _errorWithStack;
  class HideStackFramesError extends Base {
    // This is a workaround for wpt tests that expect that the error
    // constructor has a `name` property of the base class.
    get ["constructor"]() {
      var __super = (...args) => {
        super(...args);
        __privateAdd(this, _errorWithStack);
        return this;
      };
      return clazz;
    }
    constructor(...args2) {
      if (isErrorStackTraceLimitWritable()) {
        const limit = Error.stackTraceLimit;
        Error.stackTraceLimit = 0;
        __super(...args2);
        Error.stackTraceLimit = limit;
      } else {
        __super(...args2);
      }
      __privateSet(this, _errorWithStack, new ErrorWithStack());
      __privateGet(this, _errorWithStack).stack = hideInternalStackFrames(__privateGet(this, _errorWithStack).stack ?? "");
    }
    // use `getter` here to avoid the stack trace being captured by loggers
    get errorWithStack() {
      return __privateGet(this, _errorWithStack);
    }
  }
  _errorWithStack = new WeakMap();
  return HideStackFramesError;
}
```

current:

```js
function makeErrorForHideStackFrame(Base, clazz) {
  class HideStackFramesError extends Base {
    #errorWithStack;
    constructor(...args) {
      if (isErrorStackTraceLimitWritable()) {
        const limit = Error.stackTraceLimit;
        Error.stackTraceLimit = 0;
        super(...args);
        Error.stackTraceLimit = limit;
      } else {
        super(...args);
      }
      this.#errorWithStack = new ErrorWithStack();
      this.#errorWithStack.stack = hideInternalStackFrames(this.#errorWithStack.stack ?? "");
    }
    // use `getter` here to avoid the stack trace being captured by loggers
    get errorWithStack() {
      return this.#errorWithStack;
    }
    // This is a workaround for wpt tests that expect that the error
    // constructor has a `name` property of the base class.
    get ["constructor"]() {
      return clazz;
    }
  }
  return HideStackFramesError;
}
```