### PR TITLE
feat: add `declareEndpoint`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -99,3 +99,5 @@ export const createClient = <R extends Router | Router["endpoints"]>(options: Cl
 		})) as any;
 	};
 };
+
+export { type EndpointDefinition, declareEndpoint } from "./shared";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from "./context";
 export * from "./to-response";
 export * from "./helper";
 export * from "./standard-schema";
+export { type EndpointDefinition, declareEndpoint } from "./shared";

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared functions for both client and server
+ */
+import type { EndpointOptions } from "./endpoint";
+
+/**
+ * @experimental
+ */
+export type EndpointDefinition<Path extends string, Options extends EndpointOptions> = {
+	path: Path;
+	options: Options;
+};
+
+/**
+ * Declare an endpoint without a handler, useful for sharing endpoint definitions between client and server.
+ *
+ * @experimental
+ */
+export function declareEndpoint<Path extends string, Options extends EndpointOptions>(
+	path: Path,
+	options: Options,
+): EndpointDefinition<Path, Options> {
+	return {
+		path,
+		options,
+	};
+}


### PR DESCRIPTION
experimental API. I'm trying to use this in better-auth to share some info between the client and server side.

For example: the path, so we can do proxy layer