### PR TITLE
chore: uninstall uncrypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "@better-auth/utils": "^0.3.0",
     "@better-fetch/fetch": "^1.1.4",
     "rou3": "^0.5.1",
-    "set-cookie-parser": "^2.7.1",
-    "uncrypto": "^0.1.3"
+    "set-cookie-parser": "^2.7.1"
   },
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       set-cookie-parser:
         specifier: ^2.7.1
         version: 2.7.1
-      uncrypto:
-        specifier: ^0.1.3
-        version: 0.1.3
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.16.4


### PR DESCRIPTION
`uncrypto` is not used anywhere in this package. It should be removable.

It was added in [this commit](https://github.com/Bekacru/better-call/commit/9ec4024169ff45c7dca89ba6baa04406823bce19), but doesn't have any references there too.