### PR TITLE
router: expose 'addEndpoint' to allow to dynamically add endpoints

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -397,3 +397,32 @@ describe("error handling", () => {
 		expect(body.message).toBe("Resource not found");
 	});
 });
+
+describe("addEndpoint", () => {
+	it("should add an endpoint to existing router", async () => {
+		const router = createRouter({});
+
+		router.addEndpoint(createEndpoint(
+			"/dynamic_added",
+			{
+				method: "POST",
+			},
+			async (c) => {
+				return { message: "dynamically added", body: c.body };
+			},
+		));
+
+		const dynamicRequest = new Request("http://localhost/dynamic_added", {
+			method: "POST",
+			body: JSON.stringify({ test: "data" }),
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+		const dynamicResponse = await router.handler(dynamicRequest);
+		expect(dynamicResponse.status).toBe(200);
+		const jsonResponse = await dynamicResponse.json();
+		expect(jsonResponse.message).toBe("dynamically added");
+		expect(jsonResponse.body).toEqual({ test: "data" });
+	});
+});

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, assert } from "vitest";
 import { createEndpoint, type Endpoint } from "./endpoint";
 import { createRouter } from "./router";
 import { z } from "zod";
@@ -398,11 +398,13 @@ describe("error handling", () => {
 	});
 });
 
-describe("addEndpoint", () => {
-	it("should add an endpoint to existing router", async () => {
-		const router = createRouter({});
+describe("extend", () => {
+	it("should extend the router with new endpoints", async () => {
+		const initialEndpoint = createEndpoint("/initial", { method: "GET" }, async () => ({}));
+		const router = createRouter({ initialEndpoint });
+		assert.ok(router.endpoints.initialEndpoint.path === "/initial");
 
-		router.addEndpoint(createEndpoint(
+		const dynamicEndpoint = createEndpoint(
 			"/dynamic_added",
 			{
 				method: "POST",
@@ -410,7 +412,11 @@ describe("addEndpoint", () => {
 			async (c) => {
 				return { message: "dynamically added", body: c.body };
 			},
-		));
+		);
+
+		const extendedRouter = router.extend({ dynamicEndpoint });
+		assert.ok(extendedRouter.endpoints.initialEndpoint.path === "/initial");
+		assert.ok(extendedRouter.endpoints.dynamicEndpoint.path === "/dynamic_added");
 
 		const dynamicRequest = new Request("http://localhost/dynamic_added", {
 			method: "POST",
@@ -419,10 +425,11 @@ describe("addEndpoint", () => {
 				"Content-Type": "application/json",
 			},
 		});
-		const dynamicResponse = await router.handler(dynamicRequest);
+		const dynamicResponse = await extendedRouter.handler(dynamicRequest);
 		expect(dynamicResponse.status).toBe(200);
 		const jsonResponse = await dynamicResponse.json();
 		expect(jsonResponse.message).toBe("dynamically added");
 		expect(jsonResponse.body).toEqual({ test: "data" });
 	});
+
 });

--- a/src/router.ts
+++ b/src/router.ts
@@ -99,12 +99,7 @@ export const createRouter = <E extends Record<string, Endpoint>, Config extends 
 	const router = createRou3Router();
 	const middlewareRouter = createRou3Router();
 
-	for (const endpoint of Object.values(endpoints)) {
-		if (!endpoint.options) {
-			continue;
-		}
-		if (endpoint.options?.metadata?.SERVER_ONLY) continue;
-
+	const addEndpoint = (endpoint: Endpoint) => {
 		const methods = Array.isArray(endpoint.options?.method)
 			? endpoint.options.method
 			: [endpoint.options?.method];
@@ -112,6 +107,13 @@ export const createRouter = <E extends Record<string, Endpoint>, Config extends 
 		for (const method of methods) {
 			addRoute(router, method, endpoint.path, endpoint);
 		}
+	};
+
+	for (const endpoint of Object.values(endpoints)) {
+		if (!endpoint.options || endpoint.options?.metadata?.SERVER_ONLY) {
+			continue;
+		}
+		addEndpoint(endpoint);
 	}
 
 	if (config?.routerMiddleware?.length) {
@@ -226,6 +228,7 @@ export const createRouter = <E extends Record<string, Endpoint>, Config extends 
 	};
 
 	return {
+		addEndpoint,
 		handler: async (request: Request) => {
 			const onReq = await config?.onRequest?.(request);
 			if (onReq instanceof Response) {


### PR DESCRIPTION
Hi there, 

I'm starting to use `better-call` for http routes on upcoming version of [Colyseus](https://docs.colyseus.io/) and felt the need for dynamically adding routes to an existing Router.

**Proposed API:**

```typescript
const router = createRouter({/* initial routes */});

// dynamically adding new routes
router.addEndpoint(createEndpoint("/dynamic_added", { method: "POST", }, async (c) => {
    return { message: "dynamically added", body: c.body };
}));
```

I'm happy to update this PR if you have any feedback. Let me know what you think.

All the best!