### PR TITLE
feat: adding custom response status support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,27 @@ const items = await client("/item", {
 
 ### Returning non 200 responses
 
-To return a non 200 response, you will need to throw Better Call's `APIError` error. If the endpoint is called as a function, the error will be thrown but if it's mounted to a router, the error will be converted to a response object with the correct status code and headers.
+There are several supported ways to a non 200 response:
+
+You can use the `ctx.setStatus(status)` helper to change the default status code of a successful response:
+
+```ts
+const createItem = createEndpoint("/item", {
+    method: "POST",
+    body: z.object({
+        id: z.string()
+    })
+}, async (ctx) => {
+    ctx.setStatus(201);
+    return {
+        item: {
+            id: ctx.body.id
+        }
+    }
+})
+```
+
+Sometimes, you want to respond with an error, in those cases you will need to throw Better Call's `APIError` error. If the endpoint is called as a function, the error will be thrown but if it's mounted to a router, the error will be converted to a response object with the correct status code and headers.
 
 ```ts
 const createItem = createEndpoint("/item", {
@@ -119,6 +139,23 @@ const createItem = createEndpoint("/item", {
             id: ctx.body.id
         }
     }
+})
+```
+
+Finally, you can return a new `Response` object. In this case, the `ctx.setStatus()` call will be ignored, as the `Response` will have completely control over the final status code:
+
+```ts
+const createItem = createEndpoint("/item", {
+    method: "POST",
+    body: z.object({
+        id: z.string()
+    })
+}, async (ctx) => {
+    return Response.json({
+        item: {
+            id: ctx.body.id
+        }
+    }, { status: 201 });
 })
 ```
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -166,6 +166,7 @@ export type InputContext<
 	InferHeadersInput<Options> & {
 		asResponse?: boolean;
 		returnHeaders?: boolean;
+		returnStatus?: boolean;
 		use?: Middleware[];
 	};
 
@@ -180,6 +181,8 @@ export const createInternalContext = async (
 	},
 ) => {
 	const headers = new Headers();
+	let responseStatus: Status | undefined = undefined;
+
 	const { data, error } = await runValidation(options, context);
 	if (error) {
 		throw new APIError(400, {
@@ -197,6 +200,7 @@ export const createInternalContext = async (
 				: new Headers();
 	const requestCookies = requestHeaders.get("cookie");
 	const parsedCookies = requestCookies ? parseCookies(requestCookies) : undefined;
+
 	const internalContext = {
 		...context,
 		body: data.body,
@@ -275,6 +279,9 @@ export const createInternalContext = async (
 		) => {
 			return new APIError(status, body, headers);
 		},
+		setStatus: (status: Status) => {
+			responseStatus = status;
+		},
 		json: (
 			json: Record<string, any>,
 			routerResponse?:
@@ -296,6 +303,9 @@ export const createInternalContext = async (
 			};
 		},
 		responseHeaders: headers,
+		get responseStatus() {
+			return responseStatus;
+		},
 	};
 	//if context was shimmed through the input we want to apply it
 	for (const middleware of options.use || []) {

--- a/src/endpoint.test.ts
+++ b/src/endpoint.test.ts
@@ -403,6 +403,110 @@ describe("response", () => {
 			}
 		});
 	});
+	
+	describe("setStatus", () => {
+		it("should provide access to the response status on a plain object", async () => {
+			const endpoint = createEndpoint(
+				"/path",
+				{
+					method: "POST",
+				},
+				async (ctx) => {
+					ctx.setStatus(201);
+					return { test: "response" };
+				},
+			);
+			const response = await endpoint({
+				returnStatus: true,
+			});
+			expect(response.status).toBe(201);
+			expect(response.response).toMatchObject({
+				test: "response",
+			});
+		});
+
+		it("should provide access to the response status and headers on a plain object", async () => {
+			const endpoint = createEndpoint(
+				"/path",
+				{
+					method: "POST",
+				},
+				async (ctx) => {
+					ctx.setStatus(201);
+					return { test: "response" };
+				},
+			);
+			const response = await endpoint({
+				returnStatus: true,
+				returnHeaders: true,
+			});
+			expect(response.status).toBe(201);
+			expect(response.headers).toBeInstanceOf(Headers);
+			expect(response.response).toMatchObject({
+				test: "response",
+			});
+		});
+
+		it("should provide access to the response status and headers on ctx.json()", async () => {
+			const endpoint = createEndpoint(
+				"/path",
+				{
+					method: "POST",
+				},
+				async (ctx) => {
+					ctx.setStatus(201);
+					return ctx.json({ test: "response" });
+				},
+			);
+			const response = await endpoint({
+				returnStatus: true,
+			});
+			expect(response.status).toBe(201);
+			expect(response.response).toMatchObject({
+				test: "response"
+			});
+		});
+
+		it("should provide access to the response status and headers on a plain object (as response)", async () => {
+			const endpoint = createEndpoint(
+				"/path",
+				{
+					method: "POST",
+				},
+				async (ctx) => {
+					ctx.setStatus(201);
+					return { test: "response" };
+				},
+			);
+			const response = await endpoint({
+				asResponse: true,
+			});
+			expect(response.status).toBe(201);
+			expect(response.headers).toBeInstanceOf(Headers);
+			expect(await response.json()).toMatchObject({
+				test: "response"
+			});
+		});
+
+		it("should provide access to the response status and headers on a response object", async () => {
+			const endpoint = createEndpoint(
+				"/path",
+				{
+					method: "POST",
+				},
+				async (ctx) => {
+					ctx.setStatus(201); // ignored
+					return Response.json({ test: "response" });
+				},
+			);
+			const response = await endpoint();
+			expect(response.status).toBe(200);
+			expect(response.headers).toBeInstanceOf(Headers);
+			expect(await response.json()).toMatchObject({
+				test: "response"
+			});
+		});
+	});
 
 	describe("json", () => {
 		it("should return a js object response on direct call", async () => {


### PR DESCRIPTION
**What is the problem?**
Currently, it is not possible to customize the response status code when:

- A plain object is returned from the request handler
- The `ctx.json(json, { status })` helper is used to return a response but the response is unwrapped to a plain object (e.g `asResponse` set to `false`)

In either case, it is not currently possible for consumers to know what the response status is, so the only possible behavior for them is to default to `200`. 

**What is changing?**
To aid the consumer in those scenarios, where are adding a new `ctx.setStatus(statusCode)` helper, which can be used by handlers to customize the response status code in these cases. This new helper will:

- Change the default status code for plain objects that are automatically wrapped to a `Response` object (e.g `asResponse` set to `true`)
- When combined with `returnStatus`, consumers will be able to get a reference to the response status code. This is similar to the `returnHeaders` option which allows consumers to get a reference to the response headers.
