### PR TITLE
chore: rename status codes export

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import type { EndpointOptions } from "./endpoint";
-import { _statusCode, APIError, type Status } from "./error";
+import { statusCodes, APIError, type Status } from "./error";
 import type {
 	InferParamPath,
 	InferParamWildCard,
@@ -269,7 +269,7 @@ export const createInternalContext = async (
 			return new APIError("FOUND", undefined, headers);
 		},
 		error: (
-			status: keyof typeof _statusCode | Status,
+			status: keyof typeof statusCodes | Status,
 			body?:
 				| {
 						message?: string;

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -14,7 +14,7 @@ import {
 	type Method,
 } from "./context";
 import type { CookieOptions, CookiePrefixOptions } from "./cookies";
-import { type APIError, type _statusCode, type Status, BetterCallError } from "./error";
+import { type APIError, type statusCodes, type Status, BetterCallError } from "./error";
 import type { OpenAPIParameter, OpenAPISchemaType } from "./openapi";
 import type { StandardSchemaV1 } from "./standard-schema";
 import { isAPIError } from "./utils";
@@ -349,7 +349,7 @@ export type EndpointContext<Path extends string, Options extends EndpointOptions
 	 * Return error
 	 */
 	error: (
-		status: keyof typeof _statusCode | Status,
+		status: keyof typeof statusCodes | Status,
 		body?: {
 			message?: string;
 			code?: string;

--- a/src/error.ts
+++ b/src/error.ts
@@ -69,7 +69,7 @@ export function makeErrorForHideStackFrame<B extends new (...args: any[]) => Err
 	return HideStackFramesError as any;
 }
 
-export const _statusCode = {
+export const statusCodes = {
 	OK: 200,
 	CREATED: 201,
 	ACCEPTED: 202,
@@ -189,7 +189,7 @@ export type Status =
 
 class InternalAPIError extends Error {
 	constructor(
-		public status: keyof typeof _statusCode | Status = "INTERNAL_SERVER_ERROR",
+		public status: keyof typeof statusCodes | Status = "INTERNAL_SERVER_ERROR",
 		public body:
 			| ({
 					message?: string;
@@ -198,7 +198,7 @@ class InternalAPIError extends Error {
 			  } & Record<string, any>)
 			| undefined = undefined,
 		public headers: HeadersInit = {},
-		public statusCode = typeof status === "number" ? status : _statusCode[status],
+		public statusCode = typeof status === "number" ? status : statusCodes[status],
 	) {
 		super(
 			body?.message,


### PR DESCRIPTION
#### What is changing?
Renaming `_statusCode` as `statusCodes` to signal that it is part of the public API and thus can be relied upon for consumption.