### PR TITLE
fix(client): correct return types when throw option is true

### DIFF
--- a/packages/better-call/src/client.test.ts
+++ b/packages/better-call/src/client.test.ts
@@ -332,4 +332,29 @@ describe("client", () => {
 		});
 		client("/test2", { body: undefined, query: undefined, params: undefined });
 	});
+
+	it("should return unwrapped type T when throw: true is set", async () => {
+		const itemEndpoint = createEndpoint(
+			"/item",
+			{ method: "GET" },
+			async () => ({ id: "123", name: "test" }),
+		);
+
+		const router = createRouter({ itemEndpoint });
+
+		const client = createClient<typeof router>({
+			baseURL: "http://localhost:3000",
+			customFetchImpl: async (url, init) => {
+				return router.handler(new Request(url, init));
+			},
+		});
+
+		const res = await client("/item", {
+			throw: true,
+		});
+
+		expect(res).toMatchObject({ id: "123", name: "test" });
+
+		expectTypeOf(res).toExtend<{ id: string; name: string }>();
+	});
 });

--- a/packages/better-call/src/client.ts
+++ b/packages/better-call/src/client.ts
@@ -97,8 +97,11 @@ export type RequiredOptionKeys<
 				params: true;
 			});
 
-export const createClient = <R extends Router | Router["endpoints"]>(
-	options?: ClientOptions,
+export const createClient = <
+	R extends Router | Router["endpoints"],
+	GlobalOpts extends ClientOptions = ClientOptions,
+>(
+	options?: GlobalOpts,
 ) => {
 	const fetch = createFetch(options ?? {});
 	type API = InferClientRoutes<
@@ -121,23 +124,30 @@ export const createClient = <R extends Router | Router["endpoints"]>(
 		OPT extends O,
 		K extends keyof OPT,
 		C extends InferContext<OPT[K]>,
+		CallOpts extends BetterFetchOption<C["body"], C["query"], C["params"]>,
 	>(
 		path: K,
-		...options: HasRequired<C> extends true
+		...callOptions: HasRequired<C> extends true
 			? [
 					WithRequired<
 						BetterFetchOption<C["body"], C["query"], C["params"]>,
 						keyof RequiredOptionKeys<C>
 					>,
 				]
-			: [BetterFetchOption<C["body"], C["query"], C["params"]>?]
+			: [CallOpts?]
 	): Promise<
 		BetterFetchResponse<
-			Awaited<ReturnType<OPT[K] extends Endpoint ? OPT[K] : never>>
+			Awaited<ReturnType<OPT[K] extends Endpoint ? OPT[K] : never>>,
+			unknown,
+			CallOpts["throw"] extends boolean
+				? CallOpts["throw"]
+				: GlobalOpts["throw"] extends true
+					? true
+					: false
 		>
 	> => {
 		return (await fetch(path as string, {
-			...options[0],
+			...callOptions[0],
 		})) as any;
 	};
 };


### PR DESCRIPTION
When throw: true is set in client options, the response type should be the data directly, not { data, error } wrapper. This fix uses the third generic parameter of BetterFetchResponse to properly infer the return type based on the throw option.