### PR TITLE
fix: move res.end() outside stream reading loop in setResponse

### DIFF
--- a/packages/better-call/src/adapters/node/request.test.ts
+++ b/packages/better-call/src/adapters/node/request.test.ts
@@ -385,6 +385,41 @@ describe("getRequest", () => {
 });
 
 describe("setResponse", () => {
+	it("should write the full response body when it spans multiple chunks", async () => {
+		const socket = new Socket();
+		const req = new IncomingMessage(socket);
+		const res = new ServerResponse(req);
+
+		const chunks: Buffer[] = [];
+		let ended = false;
+
+		res.writeHead = vi.fn().mockReturnValue(res);
+		res.write = vi.fn().mockImplementation((chunk: Buffer) => {
+			chunks.push(Buffer.from(chunk));
+			return true;
+		});
+		res.end = vi.fn().mockImplementation(() => {
+			ended = true;
+			return res;
+		});
+
+		// Create a response body larger than 16KB to ensure multiple chunks
+		const largePayload = JSON.stringify({
+			data: "x".repeat(32 * 1024),
+		});
+
+		const webResponse = new Response(largePayload, {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+
+		await setResponse(res, webResponse);
+
+		const fullBody = Buffer.concat(chunks).toString();
+		expect(fullBody).toBe(largePayload);
+		expect(ended).toBe(true);
+	});
+
 	it("should set res.statusCode before writeHead for middleware compatibility", async () => {
 		// Regression test for https://github.com/better-auth/better-auth/issues/7035
 		// Some frameworks/middleware read res.statusCode before writeHead is called.

--- a/packages/better-call/src/adapters/node/request.ts
+++ b/packages/better-call/src/adapters/node/request.ts
@@ -330,8 +330,8 @@ export async function setResponse(res: ServerResponse, response: Response) {
 						return;
 					}
 				}
-				res.end();
 			}
+			res.end();
 		} catch (error) {
 			cancel(error instanceof Error ? error : new Error(String(error)));
 		}


### PR DESCRIPTION
## Problem

`setResponse()` in the Node.js adapter calls `res.end()` **inside** the stream reading loop (after a successful `res.write()`), causing the HTTP response to be terminated after the first chunk (~16KB). Any response body larger than one chunk is silently truncated, returning incomplete/malformed JSON to the client.

This affects applications using better-auth's `customSession` plugin where the session payload exceeds 16KB (common with production user data containing assignments, projects, divisions, etc.). The client receives truncated JSON, parses it as `null`, and the user appears unauthenticated.

## Root Cause

```typescript
// Before (broken):
async function next() {
    try {
        for (;;) {
            const { done, value } = await reader.read();
            if (done) break;
            if (!res.write(value)) {
                // backpressure handling...
            }
            res.end(); // ← called inside loop, ends response after first chunk
        }
    } catch (error) { ... }
}
```

## Fix

Move `res.end()` after the loop:

```typescript
// After (fixed):
async function next() {
    try {
        for (;;) {
            const { done, value } = await reader.read();
            if (done) break;
            if (!res.write(value)) {
                // backpressure handling...
            }
        }
        res.end(); // ← called after loop, full response is written
    } catch (error) { ... }
}
```

## Test

Added a test that creates a response body larger than 16KB and verifies the full body is written to the Node.js response without truncation.