### PR TITLE
feat(context): expose `responseHeaders` on `EndpointContext`

### DIFF
--- a/packages/better-call/src/context.ts
+++ b/packages/better-call/src/context.ts
@@ -149,6 +149,22 @@ export type EndpointContext<
 		options?: CookieOptions,
 	) => Promise<string>;
 	/**
+	 * Response headers
+	 *
+	 * The live `Headers` for the response being built in the current
+	 * request. Read it to inspect what has already been queued, e.g. to
+	 * avoid emitting a `Set-Cookie` twice or to check headers set by an
+	 * earlier handler in the chain.
+	 *
+	 * @example
+	 * ```ts
+	 * const alreadySet = ctx.responseHeaders
+	 *   .getSetCookie()
+	 *   .some((c) => c.startsWith("session="));
+	 * ```
+	 */
+	responseHeaders: Headers;
+	/**
 	 * JSON
 	 *
 	 * A helper function to create a JSON response with the correct headers

--- a/packages/better-call/src/endpoint.test.ts
+++ b/packages/better-call/src/endpoint.test.ts
@@ -1097,3 +1097,34 @@ describe("onAPIError", () => {
 		expect(error?.status).toBe("UNAUTHORIZED");
 	});
 });
+
+describe("responseHeaders", () => {
+	it("exposes the live response headers accumulator inside the handler", async () => {
+		const endpoint = createEndpoint("/test", { method: "GET" }, async (ctx) => {
+			ctx.setCookie("session", "abc");
+			ctx.setHeader("x-custom", "1");
+			const setCookies = ctx.responseHeaders.getSetCookie();
+			const custom = ctx.responseHeaders.get("x-custom");
+			return { setCookies, custom };
+		});
+		const result = await endpoint();
+		expect(result.custom).toBe("1");
+		expect(result.setCookies).toHaveLength(1);
+		expect(result.setCookies[0]).toMatch(/^session=abc/);
+	});
+
+	it("lets a later handler step observe what an earlier one wrote", async () => {
+		const endpoint = createEndpoint("/test", { method: "GET" }, async (ctx) => {
+			ctx.setCookie("first", "v1");
+			const alreadySet = ctx.responseHeaders
+				.getSetCookie()
+				.some((c) => c.startsWith("first="));
+			if (!alreadySet) {
+				ctx.setCookie("first", "v2");
+			}
+			return { count: ctx.responseHeaders.getSetCookie().length };
+		});
+		const result = await endpoint();
+		expect(result.count).toBe(1);
+	});
+});


### PR DESCRIPTION
Related to https://github.com/better-auth/better-auth/pull/8161