### PR TITLE
ci(backport): drop persist-credentials false and unnecessary fetch-depth

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -45,8 +45,6 @@ jobs:
 
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          fetch-depth: 0
-          persist-credentials: false
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Check PR state and labels


### PR DESCRIPTION
### Issue
https://github.com/better-auth/better-call/pull/130#issuecomment-4339555445

### References
- https://github.com/neovim/neovim/blob/master/.github/workflows/backport.yml
- https://github.com/NixOS/nixpkgs/blob/master/.github/workflows/backport.yml