### PR TITLE
fix(router): only strip basePath when it is a leading prefix

### DIFF
--- a/packages/better-call/src/router.test.ts
+++ b/packages/better-call/src/router.test.ts
@@ -1124,6 +1124,63 @@ describe("base path", () => {
 		const text = await response.text();
 		expect(text).toBe("hello world");
 	});
+
+	it("should not route a path where the base path is not a leading prefix", async () => {
+		const endpoint = createEndpoint(
+			"/test",
+			{
+				method: "GET",
+			},
+			async () => {
+				return "hello world";
+			},
+		);
+		const router = createRouter({ endpoint }, { basePath: "/api" });
+		// The base path appears mid-path, not as a leading prefix, so it should
+		// not be stripped and the request should not resolve onto "/test".
+		const response = await router.handler(
+			new Request("http://localhost/x/api/test"),
+		);
+		expect(response.status).toBe(404);
+	});
+
+	it("should not invoke a handler when the base path appears after another segment", async () => {
+		let called = false;
+		const endpoint = createEndpoint(
+			"/test",
+			{
+				method: "GET",
+			},
+			async () => {
+				called = true;
+				return "hello world";
+			},
+		);
+		const router = createRouter({ endpoint }, { basePath: "/api" });
+		const response = await router.handler(
+			new Request("http://localhost/foo/api/test"),
+		);
+		expect(response.status).toBe(404);
+		expect(called).toBe(false);
+	});
+
+	it("should normalize a base path with a trailing slash", async () => {
+		const endpoint = createEndpoint(
+			"/test",
+			{
+				method: "GET",
+			},
+			async () => {
+				return "hello world";
+			},
+		);
+		const router = createRouter({ endpoint }, { basePath: "/api/" });
+		const response = await router.handler(
+			new Request("http://localhost/api/test"),
+		);
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("hello world");
+	});
 });
 
 /**

--- a/packages/better-call/src/router.test.ts
+++ b/packages/better-call/src/router.test.ts
@@ -1181,6 +1181,28 @@ describe("base path", () => {
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("hello world");
 	});
+
+	it("should not route when the base path matches without a '/' boundary", async () => {
+		let called = false;
+		const endpoint = createEndpoint(
+			"/test",
+			{
+				method: "GET",
+			},
+			async () => {
+				called = true;
+				return "hello world";
+			},
+		);
+		const router = createRouter({ endpoint }, { basePath: "/admin" });
+		// "/admin" is a leading substring of "/administrator" but not a
+		// "/"-boundary prefix, so the request must not resolve onto "/test".
+		const response = await router.handler(
+			new Request("http://localhost/administrator/test"),
+		);
+		expect(response.status).toBe(404);
+		expect(called).toBe(false);
+	});
 });
 
 /**

--- a/packages/better-call/src/router.ts
+++ b/packages/better-call/src/router.ts
@@ -160,23 +160,28 @@ export const createRouter = <
 	const processRequest = async (request: Request) => {
 		const url = new URL(request.url);
 		const pathname = url.pathname;
-		const path =
-			config?.basePath && config.basePath !== "/"
-				? pathname
-						.split(config.basePath)
-						.reduce((acc, curr, index) => {
-							if (index !== 0) {
-								if (index > 1) {
-									acc.push(`${config.basePath}${curr}`);
-								} else {
-									acc.push(curr);
-								}
-							}
-							return acc;
-						}, [] as string[])
-						.join("")
-				: url.pathname;
-		if (!path?.length) {
+		// Strip `basePath` only when it is a leading, "/"-boundary prefix of the
+		// request pathname. A pathname that does not start with the configured
+		// basePath is outside this router and resolves to a 404. The previous
+		// implementation stripped basePath wherever it occurred
+		// (`pathname.split(basePath)`), which let a path like "/x/api/test"
+		// resolve onto the internal route "/test" even though it is not mounted
+		// under basePath.
+		let path: string | null;
+		if (config?.basePath && config.basePath !== "/") {
+			// Normalize trailing slashes so "/api/auth/" and "/api/auth" behave the same.
+			const normalizedBasePath = config.basePath.replace(/\/+$/, "");
+			if (!normalizedBasePath) {
+				path = pathname;
+			} else if (pathname.startsWith(`${normalizedBasePath}/`)) {
+				path = pathname.slice(normalizedBasePath.length);
+			} else {
+				path = null;
+			}
+		} else {
+			path = url.pathname;
+		}
+		if (path === null || path.length === 0) {
 			return new Response(null, { status: 404, statusText: "Not Found" });
 		}
 

--- a/packages/better-call/src/router.ts
+++ b/packages/better-call/src/router.ts
@@ -157,36 +157,37 @@ export const createRouter = <
 		}
 	}
 
+	// Normalize the configured base path once. `basePath` is configuration, not
+	// per-request input, so trailing-slash normalization belongs here rather than
+	// in the request hot path. An empty result (unset, "/", or all slashes) means
+	// "no base path": route on the full pathname.
+	const basePath =
+		config?.basePath && config.basePath !== "/"
+			? config.basePath.replace(/\/+$/, "")
+			: "";
+
 	const processRequest = async (request: Request) => {
 		const url = new URL(request.url);
 		const pathname = url.pathname;
 		// Strip `basePath` only when it is a leading, "/"-boundary prefix of the
 		// request pathname. A pathname that does not start with the configured
-		// basePath is outside this router and resolves to a 404. The previous
-		// implementation stripped basePath wherever it occurred
-		// (`pathname.split(basePath)`), which let a path like "/x/api/test"
-		// resolve onto the internal route "/test" even though it is not mounted
-		// under basePath.
-		let path: string | null;
-		if (config?.basePath && config.basePath !== "/") {
-			// Normalize trailing slashes so "/api/auth/" and "/api/auth" behave the same.
-			const normalizedBasePath = config.basePath.replace(/\/+$/, "");
-			if (!normalizedBasePath) {
-				path = pathname;
-			} else if (pathname.startsWith(`${normalizedBasePath}/`)) {
-				path = pathname.slice(normalizedBasePath.length);
-			} else {
-				path = null;
+		// basePath is outside this router and resolves to a 404, so a path like
+		// "/x/api/test" never reaches "/test". The "/" boundary also rejects a
+		// path where basePath is only a leading substring, not a full segment.
+		// The previous implementation stripped basePath wherever it occurred
+		// (`pathname.split(basePath)`).
+		let path: string;
+		if (basePath) {
+			if (!pathname.startsWith(`${basePath}/`)) {
+				return new Response(null, { status: 404, statusText: "Not Found" });
 			}
+			path = pathname.slice(basePath.length);
 		} else {
-			path = url.pathname;
-		}
-		if (path === null || path.length === 0) {
-			return new Response(null, { status: 404, statusText: "Not Found" });
+			path = pathname;
 		}
 
-		// Reject paths with consecutive slashes
-		if (/\/{2,}/.test(path)) {
+		// Reject empty paths and paths with consecutive slashes.
+		if (path.length === 0 || /\/{2,}/.test(path)) {
 			return new Response(null, { status: 404, statusText: "Not Found" });
 		}
 


### PR DESCRIPTION
## Summary

The router derived the route path by stripping `basePath` wherever it occurred in the request pathname (`pathname.split(basePath)`). That dropped any segments before the first occurrence of `basePath`, so a pathname like `/x/api/test` resolved onto the internal route `/test` even though it was not mounted under `basePath`.

This changes the router to strip `basePath` only when it is a leading, `/`-boundary prefix of the request pathname. A pathname that does not start with the configured `basePath` now resolves to a `404`. Trailing slashes on `basePath` are normalized so `/api/auth/` and `/api/auth` behave the same.

## Behavior change

- Requests where `basePath` is not a leading prefix (e.g. `/x/api/test` with `basePath: "/api"`) now return `404` instead of being routed.
- Normal requests under `basePath` are unchanged.
- A `basePath` of `/` (or unset) is unchanged.

## Tests

Added router tests for:
- a pathname where `basePath` is not a leading prefix → `404`
- the handler not being invoked when `basePath` appears after another segment
- `basePath` with a trailing slash being normalized

Full suite green (183 tests).